### PR TITLE
Fix PlayerSpellsFrame inheriting incorrect scale

### DIFF
--- a/ElvUI_EltreumUI/Modules/Skins/Other/ExpandedTalents.lua
+++ b/ElvUI_EltreumUI/Modules/Skins/Other/ExpandedTalents.lua
@@ -28,13 +28,9 @@ function ElvUI_EltreumUI:ExpandedTalents()
 
 				local function adjustscale()
                     if not _G.InCombatLockdown() then
-                        local elvScale = E.db.scale or UIParent:GetEffectiveScale()
                         local expandedScale = E.db.ElvUI_EltreumUI.skins.expandedtalentscale
-                        _G.PlayerSpellsFrame:SetScale(expandedScale * elvScale)
-
-                        if E.db.ElvUI_EltreumUI.skins.classicarmory and _G.CharacterModelFrame:IsVisible() then
-                            _G.PlayerSpellsFrame:ClearAllPoints()
-                            _G.PlayerSpellsFrame:SetPoint("TOPLEFT", _G.CharacterFrame, "TOPRIGHT", -30 / elvScale, 0)
+                        if expandedScale ~= 1 then
+                            _G.PlayerSpellsFrame:SetScale(expandedScale)
                         end
                     end
                 end


### PR DESCRIPTION
SetScale(1) was being called unconditionally on PlayerSpellsFrame which overrides the inherited UIParent scale set by ElvUIs UI scale cvar, causing the frame to render larger than intended. Now skips the call when the value is 1, letting the frame inherit naturally. Closes #206 

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/19a05056-db21-4b12-bdd8-e0c17d1ef27b" />
