### PR TITLE
fix: guard GetUnitSpeed secret value before comparison in Maps.lua

### DIFF
--- a/ElvUI_EltreumUI/Modules/Misc/Maps.lua
+++ b/ElvUI_EltreumUI/Modules/Misc/Maps.lua
@@ -168,16 +168,18 @@ if E.Retail then
 
 							--calculate time to arrive
 							local speed = GetUnitSpeed("player") or GetUnitSpeed("vehicle")
+
+							--player speed can be secret, so protect in case there is a waypoint when it is
+							if not ElvUI_EltreumUI:IsThisASafeSecret(speed,true) then return end
+
 							local distance = C_Navigation.GetDistance()
 							local seconds = 0
 							local minutes = 0
 							if not speed or speed == 0 then
 								local _,_,flyspeed = GetUnitSpeed('player')
+								if not ElvUI_EltreumUI:IsThisASafeSecret(flyspeed,true) then return end
 								speed = flyspeed
 							end
-
-							--player speed can be secret, so protect in case there is a waypoint when it is
-							if not ElvUI_EltreumUI:IsThisASafeSecret(GetUnitSpeed("player"),true) then return end
 
 							if IsPlayerMoving() or _G.UnitOnTaxi("player") then
 								if (not speed or speed == 0) then --might be dragonflying, calculate based on delta distance


### PR DESCRIPTION
## Problem
The ETA-to-waypoint feature spams Lua errors when `GetUnitSpeed` returns a tainted/secret value:
 
```
ElvUI_EltreumUI/Modules/Misc/Maps.lua:174: attempt to compare local 'speed'
(a secret number value, while execution tainted by 'ElvUI_EltreumUI')
```
 
This fires on every OnUpdate tick (up to 2662x in the report) whenever a waypoint is active and the player speed value is tainted.
 
## Root Cause
In `Maps.lua`, line 170 assigns `speed` from `GetUnitSpeed("player")`, which can now return a secret/tainted value. Line 174 then does `speed == 0`, which crashes because WoW prohibits comparisons on secret number values.
 
The existing `IsThisASafeSecret` guard at line 180 was correctly placed to catch this, but it runs **after** the comparison at line 174 — so the crash happens before the guard ever executes.
 
## Fix
- **Move the `IsThisASafeSecret` check** to immediately after `GetUnitSpeed` returns, before any comparison on `speed`.
- **Add a second guard** on the `flyspeed` fallback path (line 175), since `GetUnitSpeed` can also return a secret value for the third return (fly speed).
- The check now uses the already-assigned `speed` local instead of calling `GetUnitSpeed` a second time, which is slightly more efficient in the OnUpdate path.
## Testing
- Set a waypoint on the world map → no Lua error spam
- Navigate toward waypoint while mounted/flying → ETA displays correctly
- Stand still with waypoint active → no error
## File Changed
`ElvUI_EltreumUI/Modules/Misc/Maps.lua`